### PR TITLE
Update to client.pp

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -36,7 +36,7 @@
 #
 define voms::client ($vo = $name, $servers = []  ) {
    ensure_resource('class','voms::install')
-   Class[Voms::Install] -> Voms::Client[$vo]
+   Class['Voms::Install'] -> Voms::Client[$vo]
 
    file {"/etc/grid-security/vomsdir/${vo}":
                    ensure  => directory,


### PR DESCRIPTION
This is a fix for
Error: Error while evaluating a Resource Statement, Evaluation Error: Illegal Class name in class reference. A TypeReference['Voms::Install']-Type cannot be used where a String is expected.

Tested with Puppet 5.5.